### PR TITLE
Add Content Layer API example

### DIFF
--- a/src/content/docs/examples/releases-content-layer.mdx
+++ b/src/content/docs/examples/releases-content-layer.mdx
@@ -7,6 +7,8 @@ import StackBlitz from "../../../components/StackBlitz.astro";
 
 This example demonstrates a custom page, which uses the experimental [Content Layer API](https://astro.build/blog/future-of-astro-content-layer/) to list recent releases for a GitHub repository.
 
+Read [a full write-up of this technique](https://hideoo.dev/notes/starlight-list-recent-github-releases) on HiDeoo’s blog.
+
 <StackBlitz
   projectId="github-k3v5rv"
   options={{

--- a/src/content/docs/examples/releases-content-layer.mdx
+++ b/src/content/docs/examples/releases-content-layer.mdx
@@ -1,0 +1,16 @@
+---
+title: List recent releases with the Content Layer API
+description: A custom page that lists recent releases for a GitHub repository using the Content Layer API
+---
+
+import StackBlitz from "../../../components/StackBlitz.astro";
+
+This example demonstrates a custom page, which uses the experimental [Content Layer API](https://astro.build/blog/future-of-astro-content-layer/) to list recent releases for a GitHub repository.
+
+<StackBlitz
+  projectId="github-k3v5rv"
+  options={{
+    openFile:
+      "src/content/config.ts,src/pages/releases.astro,src/components/Release.astro",
+  }}
+/>

--- a/src/content/docs/examples/releases-content-layer.mdx
+++ b/src/content/docs/examples/releases-content-layer.mdx
@@ -5,7 +5,7 @@ description: A custom page that lists recent releases for a GitHub repository us
 
 import StackBlitz from "../../../components/StackBlitz.astro";
 
-This example demonstrates a custom page, which uses the experimental [Content Layer API](https://astro.build/blog/future-of-astro-content-layer/) to list recent releases for a GitHub repository.
+This example demonstrates a custom page, which uses the Content Layer API to list recent releases for a GitHub repository.
 
 Read [a full write-up of this technique](https://hideoo.dev/notes/starlight-list-recent-github-releases) on HiDeoo’s blog.
 


### PR DESCRIPTION
This PR adds a new example showing how to create a custom page that lists recent releases for a GitHub repository using the Content Layer API.

Naming-wise, as I don't think focusing only on "Content Layer API" would be the best approach, I've mostly followed the ["Generate a changelog with Git"](https://starlight-examples.netlify.app/examples/git-changelog/) example but feel free to suggest or update titles/filenames if needed.