### PR TITLE
Support skipping/filtering tests & re-enable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,14 @@ jobs:
           cache: 'pnpm'
       - run: pnpm i
       - run: pnpm t -- --skip releases-content-layer
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - run: pnpm i
+      - run: pnpm astro check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ env:
 
 jobs:
   test:
-    # Skip for now — content layer example can’t fetch required resources in CI
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,4 +27,4 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - run: pnpm i
-      - run: pnpm t
+      - run: pnpm t -- --skip releases-content-layer

--- a/README.md
+++ b/README.md
@@ -8,11 +8,43 @@ Practical examples of doing stuff in Starlight documentation sites, accompanied 
 
 All commands are run from the root of the project, from a terminal:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
+| Command                    | Action                                           |
+| :------------------------- | :----------------------------------------------- |
 | `pnpm install`             | Installs dependencies                            |
 | `pnpm run dev`             | Starts local dev server at `localhost:4321`      |
-| `pnpm run build`           | Build your production site to `./dist/`          |
-| `pnpm run preview`         | Preview your build locally, before deploying     |
+| `pnpm run build`           | Build the production site to `./dist/`           |
+| `pnpm run preview`         | Preview the build locally, before deploying      |
 | `pnpm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `pnpm run astro -- --help` | Get help using the Astro CLI                     |
+
+## Testing
+
+You can test that the projects in the `examples/` build successfully by running tests from a terminal:
+
+```sh
+pnpm t
+```
+
+### Filtering tests
+
+Run specific tests with the `--filter` flag:
+
+```sh
+# Only test the CSS icons example
+pnpm t -- --filter css-icons
+
+# Filter can be set multiple times to select a subset of tests
+pnpm t -- --filter git-authors --filter git-changelog
+```
+
+### Skipping tests
+
+Skip specific tests using the `--skip` flag:
+
+```sh
+# Test all examples except for the mathjax example:
+pnpm t -- --skip mathjax
+
+# Skip can be set multiple times to skip more than one example
+pnpm t -- --skip imported-code --skip transclusion
+```

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/starlight": "^0.32.0",
+    "@types/node": "^20",
     "astro": "^5.3.0",
     "astro-og-canvas": "^0.5.6",
     "canvaskit-wasm": "^0.39.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "node ./scripts/test.mjs",
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,16 @@ importers:
         version: 0.9.4(typescript@5.5.3)
       '@astrojs/starlight':
         specifier: ^0.32.0
-        version: 0.32.0(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
+        version: 0.32.0(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
+      '@types/node':
+        specifier: ^20
+        version: 20.17.19
       astro:
         specifier: ^5.3.0
-        version: 5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
+        version: 5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
       astro-og-canvas:
         specifier: ^0.5.6
-        version: 0.5.6(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
+        version: 0.5.6(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
       canvaskit-wasm:
         specifier: ^0.39.1
         version: 0.39.1
@@ -624,6 +627,9 @@ packages:
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
+  '@types/node@20.17.19':
+    resolution: {integrity: sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -1044,10 +1050,6 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-
-  fast-glob@3.3.2:
-    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
-    engines: {node: '>=8.6.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2001,6 +2003,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -2339,9 +2344,6 @@ packages:
       typescript: ^4.9.4 || ^5.0.2
       zod: ^3
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
@@ -2374,7 +2376,7 @@ snapshots:
       '@volar/language-core': 2.4.11
       '@volar/language-server': 2.4.11
       '@volar/language-service': 2.4.11
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       muggle-string: 0.4.1
       volar-service-css: 0.0.62(@volar/language-service@2.4.11)
       volar-service-emmet: 0.0.62(@volar/language-service@2.4.11)
@@ -2413,12 +2415,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.0.8(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))':
+  '@astrojs/mdx@4.0.8(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.1.0
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       acorn: 8.14.0
-      astro: 5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
+      astro: 5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.4
@@ -2440,18 +2442,18 @@ snapshots:
     dependencies:
       sitemap: 8.0.0
       stream-replace-string: 2.0.0
-      zod: 3.23.8
+      zod: 3.24.2
 
-  '@astrojs/starlight@0.32.0(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))':
+  '@astrojs/starlight@0.32.0(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))':
     dependencies:
-      '@astrojs/mdx': 4.0.8(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
+      '@astrojs/mdx': 4.0.8(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
       '@astrojs/sitemap': 3.2.1
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
-      astro-expressive-code: 0.40.2(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
+      astro: 5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
+      astro-expressive-code: 0.40.2(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.2
@@ -2910,9 +2912,13 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
+  '@types/node@20.17.19':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.17.19
 
   '@types/unist@2.0.10': {}
 
@@ -3018,19 +3024,19 @@ snapshots:
 
   astring@1.8.6: {}
 
-  astro-expressive-code@0.40.2(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)):
+  astro-expressive-code@0.40.2(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)):
     dependencies:
-      astro: 5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
+      astro: 5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
       rehype-expressive-code: 0.40.2
 
-  astro-og-canvas@0.5.6(astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)):
+  astro-og-canvas@0.5.6(astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)):
     dependencies:
-      astro: 5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
+      astro: 5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0)
       canvaskit-wasm: 0.39.1
       deterministic-object-hash: 2.0.2
       entities: 4.5.0
 
-  astro@5.3.0(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0):
+  astro@5.3.0(@types/node@20.17.19)(rollup@4.34.8)(typescript@5.5.3)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.4
       '@astrojs/internal-helpers': 0.5.1
@@ -3082,8 +3088,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.14.4
       vfile: 6.0.3
-      vite: 6.1.0(yaml@2.7.0)
-      vitefu: 1.0.5(vite@6.1.0(yaml@2.7.0))
+      vite: 6.1.0(@types/node@20.17.19)(yaml@2.7.0)
+      vitefu: 1.0.5(vite@6.1.0(@types/node@20.17.19)(yaml@2.7.0))
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -3444,14 +3450,6 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
-
-  fast-glob@3.3.2:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:
@@ -4948,6 +4946,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@6.19.8: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.2
@@ -5032,18 +5032,19 @@ snapshots:
       '@types/unist': 3.0.2
       vfile-message: 4.0.2
 
-  vite@6.1.0(yaml@2.7.0):
+  vite@6.1.0(@types/node@20.17.19)(yaml@2.7.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
       rollup: 4.34.8
     optionalDependencies:
+      '@types/node': 20.17.19
       fsevents: 2.3.3
       yaml: 2.7.0
 
-  vitefu@1.0.5(vite@6.1.0(yaml@2.7.0)):
+  vitefu@1.0.5(vite@6.1.0(@types/node@20.17.19)(yaml@2.7.0)):
     optionalDependencies:
-      vite: 6.1.0(yaml@2.7.0)
+      vite: 6.1.0(@types/node@20.17.19)(yaml@2.7.0)
 
   volar-service-css@0.0.62(@volar/language-service@2.4.11):
     dependencies:
@@ -5233,8 +5234,6 @@ snapshots:
     dependencies:
       typescript: 5.5.3
       zod: 3.24.2
-
-  zod@3.23.8: {}
 
   zod@3.24.2: {}
 


### PR DESCRIPTION
This PR adds `--filter` and `--skip` flags to the test command so we can re-enable tests in CI.