### PR TITLE
Update `toc-override` example important files

### DIFF
--- a/examples/toc-override/src/content/docs/index.mdx
+++ b/examples/toc-override/src/content/docs/index.mdx
@@ -14,10 +14,9 @@ This example shows an override of Starlight’s `<PageSidebar>` component to use
 - src/
   - assets/
   - content/
-  - overrides/
-    - **PageSidebar.astro** This component customizes the table of contents labelling
   - env.d.ts
-- **astro.config.mjs** The override is configured here
+  - **routeMiddleware.ts** This route middleware customizes the table of contents labelling
+- **astro.config.mjs** The route middleware is configured here
 - package.json
 
 </FileTree>


### PR DESCRIPTION
This PR updates the `toc-override` example important files to reflect the override → route middleware change.