### PR TITLE
Fix StackBlitz embeds

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -2,3 +2,6 @@
   cache-control: max-age=31536000
   cache-control: immutable
   cache-control: public
+
+/*
+  Cross-Origin-Embedder-Policy: credentialless

--- a/public/_headers
+++ b/public/_headers
@@ -2,6 +2,3 @@
   cache-control: max-age=31536000
   cache-control: immutable
   cache-control: public
-
-/*
-  Cross-Origin-Embedder-Policy: credentialless


### PR DESCRIPTION
Trying to get the StackBlitz embeds working again using [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy#credentialless) they now [document as required](https://developer.stackblitz.com/platform/webcontainers/browser-support#web-platform-requirements).

(Chromium only at this time)